### PR TITLE
Add chartjs outlabels plugin

### DIFF
--- a/lib/charts.js
+++ b/lib/charts.js
@@ -28,7 +28,7 @@ function addBackgroundColors(chart) {
     chart.data.datasets.forEach((dataset, dataIdx) => {
       const data = dataset;
       if (!data.backgroundColor) {
-        if (chart.type === 'pie' || chart.type === 'doughnut') {
+        if (chart.type === 'pie' || chart.type === 'doughnut' || chart.type === 'outlabeledPie' || chart.type === 'outlabeledDoughnut') {
           // Return a color for each value.
           data.backgroundColor = data.data.map(
             (_, colorIdx) => DEFAULT_COLOR_WHEEL[colorIdx % DEFAULT_COLOR_WHEEL.length],
@@ -118,7 +118,7 @@ function renderChart(width, height, backgroundColor, untrustedChart) {
     addBackgroundColors(chart);
   } else if (chart.type === 'radar') {
     addBackgroundColors(chart);
-  } else if (chart.type === 'pie' || chart.type === 'doughnut') {
+  } else if (chart.type === 'pie' || chart.type === 'doughnut' || chart.type === 'outlabeledPie' || chart.type === 'outlabeledDoughnut') {
     addBackgroundColors(chart);
   } else if (chart.type === 'scatter') {
     addBackgroundColors(chart);
@@ -135,7 +135,9 @@ function renderChart(width, height, backgroundColor, untrustedChart) {
   }
 
   chart.options.plugins = chart.options.plugins || {};
+  let usingDataLabelsDefaults = false;
   if (!chart.options.plugins.datalabels) {
+    usingDataLabelsDefaults = true;
     chart.options.plugins.datalabels = {};
     if (chart.type === 'pie' || chart.type === 'doughnut') {
       chart.options.plugins.datalabels = {
@@ -148,7 +150,28 @@ function renderChart(width, height, backgroundColor, untrustedChart) {
     }
   }
 
+  if (chart.type === 'pie' || chart.type === 'doughnut' || chart.type === 'outlabeledPie' || chart.type === 'outlabeledDoughnut') {
+    global.Chart = require('chart.js');
+    const piechartOutlabels = require('chartjs-plugin-piechart-outlabels');
+    let userSpecifiedOutlabels = false;
+    chart.data.datasets.forEach((dataset, dataIdx) => {
+      if (dataset.outlabels || chart.options.plugins.outlabels) {
+        userSpecifiedOutlabels = true;
+      } else {
+        // Disable outlabels by default.
+        dataset.outlabels = {display: false};
+      }
+    });
+
+    if (userSpecifiedOutlabels && usingDataLabelsDefaults) {
+      // If outlabels are enabled, disable datalabels by default.
+      chart.options.plugins.datalabels = {
+        display: false,
+      };
+    }
+  }
   logger.info('Chart:', JSON.stringify(chart));
+
   chart.plugins = [chartDataLabels, chartAnnotations];
   if (chart.type === 'radialGauge') {
     chart.plugins.push(chartRadialGauge);

--- a/lib/charts.js
+++ b/lib/charts.js
@@ -21,6 +21,8 @@ const DEFAULT_COLORS = {
   grey: 'rgba(201, 203, 207, 0.5)',
 };
 
+const ROUND_CHART_TYPES = new Set(['pie', 'doughnut', 'outlabeledPie', 'outlabeledDoughnut']);
+
 const DEFAULT_COLOR_WHEEL = Object.values(DEFAULT_COLORS);
 
 function addBackgroundColors(chart) {
@@ -28,7 +30,7 @@ function addBackgroundColors(chart) {
     chart.data.datasets.forEach((dataset, dataIdx) => {
       const data = dataset;
       if (!data.backgroundColor) {
-        if (chart.type === 'pie' || chart.type === 'doughnut' || chart.type === 'outlabeledPie' || chart.type === 'outlabeledDoughnut') {
+        if (ROUND_CHART_TYPES.has(chart.type)) {
           // Return a color for each value.
           data.backgroundColor = data.data.map(
             (_, colorIdx) => DEFAULT_COLOR_WHEEL[colorIdx % DEFAULT_COLOR_WHEEL.length],
@@ -118,7 +120,7 @@ function renderChart(width, height, backgroundColor, untrustedChart) {
     addBackgroundColors(chart);
   } else if (chart.type === 'radar') {
     addBackgroundColors(chart);
-  } else if (chart.type === 'pie' || chart.type === 'doughnut' || chart.type === 'outlabeledPie' || chart.type === 'outlabeledDoughnut') {
+  } else if (ROUND_CHART_TYPES.has(chart.type)) {
     addBackgroundColors(chart);
   } else if (chart.type === 'scatter') {
     addBackgroundColors(chart);
@@ -150,7 +152,7 @@ function renderChart(width, height, backgroundColor, untrustedChart) {
     }
   }
 
-  if (chart.type === 'pie' || chart.type === 'doughnut' || chart.type === 'outlabeledPie' || chart.type === 'outlabeledDoughnut') {
+  if (ROUND_CHART_TYPES.has(chart.type)) {
     global.Chart = require('chart.js');
     const piechartOutlabels = require('chartjs-plugin-piechart-outlabels');
     let userSpecifiedOutlabels = false;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "chartjs-node-canvas": "https://github.com/typpo/ChartjsNodeCanvas.git#c34802fc3c30e4d1992678134d3ee10d160f65f4",
     "chartjs-plugin-annotation": "^0.5.7",
     "chartjs-plugin-datalabels": "^0.5.0",
+    "chartjs-plugin-piechart-outlabels": "^0.1.4",
     "express": "^4.16.4",
     "express-nunjucks": "^2.2.3",
     "nunjucks": "^3.1.7",

--- a/templates/index.html
+++ b/templates/index.html
@@ -477,10 +477,13 @@
     </div>
     <h2 id="qr">Chart Annotations and Plugins</h2>
     <p>
-      Two additional Chart.js plugins are supported: Data Labels (<a href="https://github.com/chartjs/chartjs-plugin-datalabels">chartjs-plugin-datalabels</a>) and Annotations (<a href="https://github.com/chartjs/chartjs-plugin-annotation">chartjs-plugin-annotation</a>).  These allow you to add various markup to your chart.  Have a look at the documentation for each plugin to learn more about the possibilities.
+      Three additional Chart.js plugins are supported: Data Labels (<a href="https://github.com/chartjs/chartjs-plugin-datalabels">chartjs-plugin-datalabels</a>), Annotations (<a href="https://github.com/chartjs/chartjs-plugin-annotation">chartjs-plugin-annotation</a>), and Outlabels (<a href="https://github.com/Neckster/chartjs-plugin-piechart-outlabels">chartjs-plugin-piechart-outlabels</a>).  These allow you to add various markup to your chart.  Have a look at the documentation for each plugin to learn more about the possibilities.
     </p>
     <div class="hero panel">
       <div class="col">
+				<p>
+					An example of Chart.js data labels and annotations:
+				</p>
         <textarea class="sandbox-input" data-image-id="sandbox-plugin" data-tag-id="plugin-tag">{
   type: 'line',
   data: {
@@ -531,6 +534,43 @@
       <div class="col">
         <div id="plugin-tag" class="sandbox-tag"></div>
         <img class="img-example" id="sandbox-plugin" src="/chart?bkg=white&c=%7B%0A%20%20type%3A%20%27line%27%2C%0A%20%20data%3A%20%7B%0A%20%20%20%20labels%3A%20%5B1%2C2%2C3%2C4%2C5%5D%2C%0A%20%20%20%20datasets%3A%20%5B%7B%0A%20%20%20%20%20%20label%3A%20%27Rainfall%27%2C%0A%20%20%20%20%20%20data%3A%20%5B%20200%2C%2090%2C%20120%2C%20400%2C%20500%20%5D%2C%0A%20%20%20%20%20%20fill%3A%20false%2C%0A%20%20%20%20%20%20borderColor%3A%20%27green%27%2C%0A%20%20%20%20%20%20backgroundColor%3A%20%27green%27%2C%0A%20%20%20%20%7D%5D%0A%20%20%7D%2C%0A%20%20options%3A%20%7B%0A%20%20%20%20annotation%3A%20%7B%0A%20%20%20%20%20%20annotations%3A%20%5B%7B%0A%20%20%20%20%20%20%20%20type%3A%20%27line%27%2C%0A%20%20%20%20%20%20%20%20mode%3A%20%27vertical%27%2C%0A%20%20%20%20%20%20%20%20scaleID%3A%20%27x-axis-0%27%2C%0A%20%20%20%20%20%20%20%20value%3A%202%2C%0A%20%20%20%20%20%20%20%20borderColor%3A%20%27red%27%2C%0A%20%20%20%20%20%20%20%20borderWidth%3A%204%2C%0A%20%20%20%20%20%20%20%20label%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20enabled%3A%20true%2C%0A%20%20%20%20%20%20%20%20%20%20content%3A%20%27Something%20changed%27%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%2C%20%7B%0A%20%20%20%20%20%20%20%20type%3A%20%27box%27%2C%0A%09xScaleID%3A%20%27x-axis-0%27%2C%0A%09yScaleID%3A%20%27y-axis-0%27%2C%0A%20%20%20%20%20%20%20%20xMin%3A%203%2C%0A%20%20%20%20%20%20%20%20xMax%3A%205%2C%0A%20%20%20%20%20%20%20%20backgroundColor%3A%20%27rgba(200%2C%20200%2C%20200%2C%200.2)%27%2C%0A%20%20%20%20%20%20%20%20borderColor%3A%20%27%23ccc%27%2C%0A%20%20%20%20%20%20%7D%5D%0A%20%20%20%20%7D%2C%0A%20%20%20%20plugins%3A%20%7B%0A%20%20%20%20%20%20datalabels%3A%20%7B%0A%20%20%20%20%20%20%20%20display%3A%20true%2C%0A%20%20%20%20%20%20%20%20align%3A%20%27bottom%27%2C%0A%20%20%20%20%20%20%20%20backgroundColor%3A%20%27%23ccc%27%2C%0A%20%20%20%20%20%20%20%20borderRadius%3A%203%0A%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D"/>
+      </div>
+    </div>
+    <div class="hero panel">
+      <div class="col">
+				<p>
+					An example of the <code>outlabeledPie</code> type:
+				</p>
+        <textarea class="sandbox-input" data-image-id="sandbox-plugin-2" data-tag-id="plugin-tag-2">{
+  "type": "outlabeledPie",
+  "data": {
+    "labels": ["ONE", "TWO", "THREE", "FOUR", "FIVE"],
+    "datasets": [{
+        "backgroundColor": ["#FF3784", "#36A2EB", "#4BC0C0", "#F77825", "#9966FF"],
+        "data": [1, 2, 3, 4, 5]
+		}]
+  },
+  "options": {
+    "plugins": {
+      "legend": false,
+      "outlabels": {
+        "text": "%l %p",
+        "color": "white",
+        "stretch": 35,
+        "font": {
+          "resizable": true,
+          "minSize": 12,
+          "maxSize": 18
+        }
+      }
+    }
+  }
+}</textarea>
+      </div>
+      <div class="arrowcol"></div>
+      <div class="col">
+        <div id="plugin-tag-2" class="sandbox-tag"></div>
+        <img class="img-example" id="sandbox-plugin-2" src="/chart?bkg=white&c=%7B%0A%20%20%22type%22%3A%20%22outlabeledPie%22%2C%0A%20%20%22data%22%3A%20%7B%0A%20%20%20%20%22labels%22%3A%20%5B%22ONE%22%2C%20%22TWO%22%2C%20%22THREE%22%2C%20%22FOUR%22%2C%20%22FIVE%22%5D%2C%0A%20%20%20%20%22datasets%22%3A%20%5B%7B%0A%20%20%20%20%20%20%20%20%22backgroundColor%22%3A%20%5B%22%23FF3784%22%2C%20%22%2336A2EB%22%2C%20%22%234BC0C0%22%2C%20%22%23F77825%22%2C%20%22%239966FF%22%5D%2C%0A%20%20%20%20%20%20%20%20%22data%22%3A%20%5B1%2C%202%2C%203%2C%204%2C%205%5D%0A%09%09%7D%5D%0A%20%20%7D%2C%0A%20%20%22options%22%3A%20%7B%0A%20%20%20%20%22plugins%22%3A%20%7B%0A%20%20%20%20%20%20%22legend%22%3A%20false%2C%0A%20%20%20%20%20%20%22outlabels%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%22text%22%3A%20%22%25l%20%25p%22%2C%0A%20%20%20%20%20%20%20%20%22color%22%3A%20%22white%22%2C%0A%20%20%20%20%20%20%20%20%22stretch%22%3A%2035%2C%0A%20%20%20%20%20%20%20%20%22font%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%22resizable%22%3A%20true%2C%0A%20%20%20%20%20%20%20%20%20%20%22minSize%22%3A%2012%2C%0A%20%20%20%20%20%20%20%20%20%20%22maxSize%22%3A%2018%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D"/>
       </div>
     </div>
     <h2 id="qr">QR codes</h2>

--- a/yarn.lock
+++ b/yarn.lock
@@ -334,6 +334,11 @@ chartjs-plugin-datalabels@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-0.5.0.tgz#b9c7a99857b2a52b6db70f63fc9f3a65d887d523"
 
+chartjs-plugin-piechart-outlabels@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/chartjs-plugin-piechart-outlabels/-/chartjs-plugin-piechart-outlabels-0.1.4.tgz#e97e19a12202d74f9040d9e4641987c9d1e458fc"
+  integrity sha1-6X4ZoSIC10+QQNnkZBmHydHkWPw=
+
 chokidar@^1.4.3:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"


### PR DESCRIPTION
Example config:
```
{
  "type": "outlabeledDoughnut",
  "data": {
    "labels": ["ONE", "TWO", "THREE", "FOUR", "FIVE"],
    "datasets": [{
        "backgroundColor": ["#FF3784", "#36A2EB", "#4BC0C0", "#F77825", "#9966FF"],
        "data": [1, 2, 3, 4, 5]
		}]
  },
  "options": {
    "plugins": {
      "legend": false,
      "outlabels": {
        "text": "%l %p",
        "color": "white",
        "stretch": 35,
        "font": {
          "resizable": true,
          "minSize": 12,
          "maxSize": 18
        }
      }
    }
  }
}
```

Doughnut:
![image](https://user-images.githubusercontent.com/310310/59527891-aa4bb080-8e91-11e9-90c2-64f54d04d021.png)

Pie:
![image](https://user-images.githubusercontent.com/310310/59527885-a586fc80-8e91-11e9-96f5-b8bae4376743.png)