### PR TITLE
Add a devicePixelRatio parameter for charts.

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,6 +174,10 @@ function doRender(req, res, opts) {
     }
   }
 
+  // Choose retina resolution by default. This will cause images to be 2x size
+  // in absolute terms.
+  const devicePixelRatio = opts.devicePixelRatio || 2.0;
+
   let untrustedInput = opts.chart;
   if (opts.encoding === 'base64') {
     try {
@@ -187,7 +191,7 @@ function doRender(req, res, opts) {
 
   const backgroundColor = opts.backgroundColor || 'transparent';
 
-  renderChart(width, height, backgroundColor, untrustedInput)
+  renderChart(width, height, backgroundColor, devicePixelRatio, untrustedInput)
     .then(opts.onRenderHandler)
     .catch(err => {
       logger.error('Chart error', err);
@@ -201,6 +205,7 @@ app.get('/chart', (req, res) => {
     height: req.query.h || req.query.height,
     width: req.query.w || req.query.width,
     backgroundColor: req.query.backgroundColor || req.query.bkg,
+    devicePixelRatio: req.query.devicePixelRatio,
     encoding: req.query.encoding || 'url',
   };
 
@@ -221,6 +226,7 @@ app.post('/chart', (req, res) => {
     height: req.body.h || req.body.height,
     width: req.body.w || req.body.width,
     backgroundColor: req.body.backgroundColor || req.body.bkg,
+    devicePixelRatio: req.body.devicePixelRatio,
     encoding: req.body.encoding || 'url',
   };
   const outputFormat = (req.body.f || req.body.format || '').toLowerCase();

--- a/lib/charts.js
+++ b/lib/charts.js
@@ -46,7 +46,7 @@ function addBackgroundColors(chart) {
   }
 }
 
-function renderChart(width, height, backgroundColor, untrustedChart) {
+function renderChart(width, height, backgroundColor, devicePixelRatio, untrustedChart) {
   let chart;
   if (typeof untrustedChart === 'string') {
     // The chart could contain Javascript - run it in a VM.
@@ -126,7 +126,7 @@ function renderChart(width, height, backgroundColor, untrustedChart) {
   }
 
   // Implement default options
-  chart.options.devicePixelRatio = 2.0;
+  chart.options.devicePixelRatio = devicePixelRatio;
   if (
     chart.type === 'bar' ||
     chart.type === 'line' ||

--- a/templates/index.html
+++ b/templates/index.html
@@ -288,11 +288,12 @@ data: {
   <p>
     The chart endpoint accepts these query parameters:
     <ul>
-      <li><code><strong>width</strong>=500</code>: Set the width of the image. Abbreviated as "w"</li>
-      <li><code><strong>height</strong>=300</code>: Set the height of the image. Abbreviated as "h"</li>
-      <li><code><strong>backgroundColor</strong>=transparent</code>: Set the background of the chart canvas. Abbreviated as "bkg"</li>
-      <li><code><strong>format</strong>=png</code>: Set the format of your output. Currently the two supported output formats are PNG and PDF. Abbreviated as "f"</li>
-      <li><code><strong>encoding</strong>=url</code>: Select the encoding of your "chart" parameter. Accepted values are <code>url</code> and <code>base64</code>.</li>
+      <li><code><strong>width</strong>=500</code>: Width of the image. Abbreviated as "w"</li>
+      <li><code><strong>height</strong>=300</code>: Height of the image. Abbreviated as "h"</li>
+      <li><code><strong>backgroundColor</strong>=transparent</code>: Background of the chart canvas. Abbreviated as "bkg"</li>
+      <li><code><strong>format</strong>=png</code>: Format of your output. Currently the two supported output formats are PNG and PDF. Abbreviated as "f"</li>
+      <li><code><strong>devicePixelRatio</strong>=2.0</code>: Device pixel ratio of the output (defaults to retina=2.0). Note that width and height are multiplied by this value.</li>
+      <li><code><strong>encoding</strong>=url</code>: Encoding of your "chart" parameter. Accepted values are <code>url</code> and <code>base64</code>.</li>
     </ul>
     Combine these parameters in your query string. For example: <code>/chart?width=500&amp;height=300&amp;format=pdf&amp;c={...}</code>
   </p>


### PR DESCRIPTION
QuickChart defaults to devicePixelRatio of 2.0 (retina), effectively doubling absolute image size from the specified width/height.  This has confused some people.

Unfortunately for backwards compatibility reasons I can't remove the retina default, so instead I've added a `devicePixelRatio` parameter that can be passed to the chart renderer.  It defaults to 2.0 but can be set to 1.0 for non-retina behavior.

Addresses issue #5 
