### PR TITLE
Add support for configurable color wheel

### DIFF
--- a/lib/charts.js
+++ b/lib/charts.js
@@ -23,6 +23,8 @@ const DEFAULT_COLORS = {
   grey: 'rgb(201, 203, 207)',
 };
 
+const DEFAULT_COLOR_WHEEL = Object.values(DEFAULT_COLORS);
+
 const ROUND_CHART_TYPES = new Set([
   'pie',
   'doughnut',
@@ -32,8 +34,6 @@ const ROUND_CHART_TYPES = new Set([
 ]);
 
 const BOXPLOT_CHART_TYPES = new Set(['boxplot', 'horizontalBoxplot', 'violin', 'horizontalViolin']);
-
-const DEFAULT_COLOR_WHEEL = Object.values(DEFAULT_COLORS);
 
 const rendererCache = {};
 
@@ -45,7 +45,7 @@ function getRenderer(width, height) {
   return rendererCache[key];
 }
 
-function addBackgroundColors(chart) {
+function addBackgroundColors(chart, colorWheel) {
   if (chart.data && chart.data.datasets && Array.isArray(chart.data.datasets)) {
     chart.data.datasets.forEach((dataset, dataIdx) => {
       const data = dataset;
@@ -53,11 +53,11 @@ function addBackgroundColors(chart) {
         if (ROUND_CHART_TYPES.has(chart.type)) {
           // Return a color for each value.
           data.backgroundColor = data.data.map(
-            (_, colorIdx) => DEFAULT_COLOR_WHEEL[colorIdx % DEFAULT_COLOR_WHEEL.length],
+            (_, colorIdx) => colorWheel[colorIdx % colorWheel.length],
           );
         } else {
           // Return a color for each data.
-          data.backgroundColor = DEFAULT_COLOR_WHEEL[dataIdx % DEFAULT_COLOR_WHEEL.length];
+          data.backgroundColor = colorWheel[dataIdx % colorWheel.length];
         }
       }
     });
@@ -113,7 +113,14 @@ function patternDraw(shapeType, backgroundColor, patternColor, requestedSize) {
   return pattern.draw(shapeType, backgroundColor, patternColor, size);
 }
 
-function renderChart(width, height, backgroundColor, devicePixelRatio, untrustedChart) {
+function renderChart(
+  width,
+  height,
+  backgroundColor,
+  devicePixelRatio,
+  defaultColors,
+  untrustedChart,
+) {
   let chart;
   if (typeof untrustedChart === 'string') {
     // The chart could contain Javascript - run it in a VM.
@@ -260,6 +267,7 @@ function renderChart(width, height, backgroundColor, devicePixelRatio, untrusted
   }
 
   // Implement default options
+  const colorWheel = defaultColors || DEFAULT_COLOR_WHEEL;
   chart.options.devicePixelRatio = devicePixelRatio;
   if (
     chart.type === 'bar' ||
@@ -279,15 +287,15 @@ function renderChart(width, height, backgroundColor, devicePixelRatio, untrusted
         ],
       };
     }
-    addBackgroundColors(chart);
+    addBackgroundColors(chart, colorWheel);
   } else if (chart.type === 'radar') {
-    addBackgroundColors(chart);
+    addBackgroundColors(chart, colorWheel);
   } else if (ROUND_CHART_TYPES.has(chart.type)) {
-    addBackgroundColors(chart);
+    addBackgroundColors(chart, colorWheel);
   } else if (chart.type === 'scatter') {
-    addBackgroundColors(chart);
+    addBackgroundColors(chart, colorWheel);
   } else if (chart.type === 'bubble') {
-    addBackgroundColors(chart);
+    addBackgroundColors(chart, colorWheel);
   }
 
   if (chart.type === 'line') {
@@ -369,7 +377,5 @@ function renderChart(width, height, backgroundColor, devicePixelRatio, untrusted
 }
 
 module.exports = {
-  DEFAULT_COLORS,
-  DEFAULT_COLOR_WHEEL,
   renderChart,
 };

--- a/test/ci/chart_helpers.js
+++ b/test/ci/chart_helpers.js
@@ -1,70 +1,74 @@
 const javascriptStringify = require('javascript-stringify').stringify;
 
-const BASIC_CHART = {
-  type: 'bar',
-  data: {
-    labels: [2012, 2013, 2014, 2015, 2016],
-    datasets: [
-      {
-        label: 'Bananas',
-        data: [4, 8, 16, 5, 5],
-      },
-    ],
-  },
-};
-
-const JS_CHART = javascriptStringify({
-  type: 'bar',
-  data: {
-    labels: ['January', 'February', 'March', 'April', 'May'],
-    datasets: [
-      {
-        label: 'Dogs',
-        backgroundColor: 'chartreuse',
-        data: [50, 60, 70, 180, 190],
-      },
-      {
-        label: 'Cats',
-        backgroundColor: 'gold',
-        data: [100, 200, 300, 400, 500],
-      },
-    ],
-  },
-  options: {
-    title: {
-      display: true,
-      text: 'Total Revenue',
-      fontColor: 'hotpink',
-      fontSize: 32,
-    },
-    legend: {
-      position: 'bottom',
-    },
-    scales: {
-      xAxes: [{ stacked: true }],
-      yAxes: [
+function getBasicChart() {
+  return {
+    type: 'bar',
+    data: {
+      labels: [2012, 2013, 2014, 2015, 2016],
+      datasets: [
         {
-          stacked: true,
-          ticks: {
-            callback: function(value) {
-              return '$' + value;
-            },
-          },
+          label: 'Bananas',
+          data: [4, 8, 16, 5, 5],
         },
       ],
     },
-    plugins: {
-      datalabels: {
+  };
+}
+
+function getJsChart() {
+  return javascriptStringify({
+    type: 'bar',
+    data: {
+      labels: ['January', 'February', 'March', 'April', 'May'],
+      datasets: [
+        {
+          label: 'Dogs',
+          backgroundColor: 'chartreuse',
+          data: [50, 60, 70, 180, 190],
+        },
+        {
+          label: 'Cats',
+          backgroundColor: 'gold',
+          data: [100, 200, 300, 400, 500],
+        },
+      ],
+    },
+    options: {
+      title: {
         display: true,
-        font: {
-          style: 'bold',
+        text: 'Total Revenue',
+        fontColor: 'hotpink',
+        fontSize: 32,
+      },
+      legend: {
+        position: 'bottom',
+      },
+      scales: {
+        xAxes: [{ stacked: true }],
+        yAxes: [
+          {
+            stacked: true,
+            ticks: {
+              callback: function(value) {
+                return '$' + value;
+              },
+            },
+          },
+        ],
+      },
+      plugins: {
+        datalabels: {
+          display: true,
+          font: {
+            style: 'bold',
+          },
         },
       },
     },
-  },
-});
+  });
+}
 
 module.exports = {
-  BASIC_CHART,
-  JS_CHART,
+  getBasicChart,
+  getJsChart,
 };

--- a/test/ci/charts.js
+++ b/test/ci/charts.js
@@ -1,14 +1,19 @@
 /* eslint-env node, mocha */
 
 const assert = require('assert');
+
+const ColorThief = require('color-thief');
 const imageSize = require('image-size');
 
 const chartsLib = require('../../lib/charts');
-const { BASIC_CHART, JS_CHART } = require('./chart_helpers');
+const { getBasicChart, getJsChart } = require('./chart_helpers');
+const { assertSimilarRgb } = require('./color_helpers');
+
+const colorThief = new ColorThief();
 
 describe('charts.js', () => {
   it('renders a JSON chart', async () => {
-    const buf = await chartsLib.renderChart(200, 100, 'white', 1.0, BASIC_CHART);
+    const buf = await chartsLib.renderChart(200, 100, 'white', 1.0, undefined, getBasicChart());
 
     assert(buf.length > 0);
     const dimensions = imageSize(buf);
@@ -18,7 +23,7 @@ describe('charts.js', () => {
   });
 
   it('adjusts chart size based on device pixel ratio', async () => {
-    const buf = await chartsLib.renderChart(200, 100, 'white', 2.0, BASIC_CHART);
+    const buf = await chartsLib.renderChart(200, 100, 'white', 2.0, undefined, getBasicChart());
 
     assert(buf.length > 0);
     const dimensions = imageSize(buf);
@@ -28,7 +33,15 @@ describe('charts.js', () => {
   });
 
   it('renders a JS chart', async () => {
-    const buf = await chartsLib.renderChart(200, 100, 'white', 2.0, JS_CHART);
+    const buf = await chartsLib.renderChart(200, 100, 'white', 2.0, undefined, getJsChart());
     assert(buf.length > 0);
+  });
+
+  it('renders a chart with custom color wheel', async () => {
+    const buf = await chartsLib.renderChart(200, 100, 'white', 1.0, ['#ff0000'], getBasicChart());
+
+    assert(buf.length > 0);
+    const rgb = colorThief.getColor(buf);
+    assertSimilarRgb([255, 0, 0], rgb);
   });
 });

--- a/test/ci/color_helpers.js
+++ b/test/ci/color_helpers.js
@@ -39,6 +39,15 @@ function rgb2lab(rgb) {
   return [116 * y - 16, 500 * (x - y), 200 * (y - z)];
 }
 
+function assertSimilarRgb(expected, actual, tolerance = 6) {
+  const diff = deltaE(expected, actual);
+  if (diff > tolerance) {
+    throw new Error(
+      `Expected rgb ${expected} but got ${actual}, scored at diff=${diff} which is greater than ${tolerance}`,
+    );
+  }
+}
+
 module.exports = {
-  deltaE,
+  assertSimilarRgb,
 };


### PR DESCRIPTION
Add a `defaultColors` GET and POST parameter that takes a JSON list of colors.  This saves people the trouble of having to specify `backgroundColor` in their charts.

For example: 
```
http://localhost:3400/chart?bkg=white&defaultColors=["red","pink"]&c={type:'bar',data:{labels:['January','February','March','April', 'May'],datasets:[{label:'Dogs',data:[50,60,70,180,190]},{label:'Cats',data:[100,200,300,400,500]}]}}
```

![image](https://user-images.githubusercontent.com/310310/78465378-c4b57b80-76a9-11ea-960b-7cadc9507a5d.png)

I have a couple open questions to resolve:
- Should the param be `defaultColors` or is it time to create a general config param that includes default colors and other future options?
- Should the param be strict JSON, relaxed JSON, or comma-separated list of colors/hex codes?

Resolves #49 