### PR TITLE
Added ENV for setting json limit

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,11 @@ app.set('query parser', str =>
     },
   }),
 );
-app.use(express.json());
+
+app.use(express.json({
+  limit: process.env.EXPRESS_JSON_LIMIT || '100kb'
+}));
+
 app.use(express.urlencoded());
 
 if (process.env.RATE_LIMIT_PER_MIN) {


### PR DESCRIPTION
Hello,

thanks for sharing your project with us.

This pull requests adds ability to configure the limit of the JSON size by adding an environment variable called EXPRESS_JSON_LIMIT, which will be passed to express json middleware. Thought it may be useful for others too.

If not defined it will be set to 100kb (as documented in https://expressjs.com/en/api.html#express.json).

Regards
Christian