### PR TITLE
Properly decode URL params

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const isDev = app.get('env') === 'development' || app.get('env') === 'test';
 
 app.set('query parser', str =>
   qs.parse(str, {
-    decode(s) {
+    decoder(s) {
       // Default express implementation replaces '+' with space. We don't want
       // that. See https://github.com/expressjs/express/issues/3453
       return decodeURIComponent(s);


### PR DESCRIPTION
Base64 encoded query params fail if they contain a `+` because by default express replaces this with a ` `.  It looks like a fix was attempted for this by using the `extended` express `query parser` setting and decoding each param but the wrong qs function was specified (`decode` instead of `decoder`) so the default express query parser is still being used and replacing `+` characters.  See [qs](https://github.com/ljharb/qs/blob/daf3e6aeb5ba8ba7d9bef7b690a3e8dbfe70a23d/lib/parse.js#L15) for correct property.

[This]( https://quickchart.io/chart?encoding=base64&c=eyJ0eXBlIjoibGluZSIsIm9wdGlvbnMiOnt9LCJkYXRhIjp7ImxhYmVscyI6WyJwZXJmLXJlcG9ydC8xIiwicGVyZi1yZXBvcnQvMiIsInBlcmYtcmVwb3J0LzMiLCJwZXJmLXJlcG9ydC80IiwicGVyZi1yZXBvcnQvNSIsInBlcmYtcmVwb3J0LzYiXSwiZGF0YXNldHMiOlt7InR5cGUiOiJsaW5lIiwibGFiZWwiOiJ0ZXN0LXN1aXRlLTUtdGFyZ2V0cyA+IHRhcmdldC1wYXNzLXZhbHVlLTk5LXRhcmdldC0xMDAtdG9sLTEwIiwiZGF0YSI6Wy0xLC0xLC0yLDQsLTQsOS4wMDAwMDAwMDAwMDAwMTRdLCJmaWxsIjpmYWxzZX0seyJ0eXBlIjoibGluZSIsImxhYmVsIjoidGVzdC1zdWl0ZS01LXRhcmdldHMgPiB0YXJnZXQtcGFzcy12YWx1ZS0xMDAtdGFyZ2V0LTEwMC10b2wtMTAiLCJkYXRhIjpbMCwwLC0xLDUsLTMsMTAuMDAwMDAwMDAwMDAwMDE0XSwiZmlsbCI6ZmFsc2V9LHsidHlwZSI6ImxpbmUiLCJsYWJlbCI6InRlc3Qtc3VpdGUtNS10YXJnZXRzID4gdGFyZ2V0LXBhc3MtdmFsdWUtOTAtdGFyZ2V0LTEwMC10b2wtMTAiLCJkYXRhIjpbLTEwLC0xMCwtMTEsLTUsLTEzLDBdLCJmaWxsIjpmYWxzZX0seyJ0eXBlIjoibGluZSIsImxhYmVsIjoidGVzdC1zdWl0ZS01LXRhcmdldHMgPiB0YXJnZXQtcGFzcy12YWx1ZS04OS10YXJnZXQtMTAwLXRvbC0xMCIsImRhdGEiOlstMTEsLTExLC0xMiwtNiwtMTQsLTFdLCJmaWxsIjpmYWxzZX0seyJ0eXBlIjoibGluZSIsImxhYmVsIjoidGVzdC1zdWl0ZS01LXRhcmdldHMgPiB0YXJnZXQtd2Fybi12YWx1ZS0xMTAtdGFyZ2V0LTEwMC10b2wtMTAiLCJkYXRhIjpbMTAuMDAwMDAwMDAwMDAwMDE0LDEwLjAwMDAwMDAwMDAwMDAxNCw5LjAwMDAwMDAwMDAwMDAxNCwxNC45OTk5OTk5OTk5OTk5ODYsNywyMF0sImZpbGwiOmZhbHNlfSx7InR5cGUiOiJsaW5lIiwibGFiZWwiOiJ0ZXN0LXN1aXRlLTUtdGFyZ2V0cyA+IHRhcmdldC1mYWlsLXZhbHVlLTExMS10YXJnZXQtMTAwLXRvbC0xMCIsImRhdGEiOlsxMS4wMDAwMDAwMDAwMDAwMTQsMTEuMDAwMDAwMDAwMDAwMDE0LDEwLjAwMDAwMDAwMDAwMDAxNCwxNS45OTk5OTk5OTk5OTk5ODYsOCwyMV0sImZpbGwiOmZhbHNlfSx7InR5cGUiOiJsaW5lIiwibGFiZWwiOiJ0ZXN0LXN1aXRlLTUtdGFyZ2V0cyA+IHRhcmdldC1mYWlsLXZhbHVlLTEwMS10YXJnZXQtMTAwLW5vLXRvbCIsImRhdGEiOlsxLDEsMCw2LC0yLDExLjAwMDAwMDAwMDAwMDAxNF0sImZpbGwiOmZhbHNlfV19fQ==
) is a URL to reproduce this bug.

Raw JSON chart config:
```json
{"type":"line","options":{},"data":{"labels":["perf-report/1","perf-report/2","perf-report/3","perf-report/4","perf-report/5","perf-report/6"],"datasets":[{"type":"line","label":"test-suite-5-targets > target-pass-value-99-target-100-tol-10","data":[-1,-1,-2,4,-4,9.000000000000014],"fill":false},{"type":"line","label":"test-suite-5-targets > target-pass-value-100-target-100-tol-10","data":[0,0,-1,5,-3,10.000000000000014],"fill":false},{"type":"line","label":"test-suite-5-targets > target-pass-value-90-target-100-tol-10","data":[-10,-10,-11,-5,-13,0],"fill":false},{"type":"line","label":"test-suite-5-targets > target-pass-value-89-target-100-tol-10","data":[-11,-11,-12,-6,-14,-1],"fill":false},{"type":"line","label":"test-suite-5-targets > target-warn-value-110-target-100-tol-10","data":[10.000000000000014,10.000000000000014,9.000000000000014,14.999999999999986,7,20],"fill":false},{"type":"line","label":"test-suite-5-targets > target-fail-value-111-target-100-tol-10","data":[11.000000000000014,11.000000000000014,10.000000000000014,15.999999999999986,8,21],"fill":false},{"type":"line","label":"test-suite-5-targets > target-fail-value-101-target-100-no-tol","data":[1,1,0,6,-2,11.000000000000014],"fill":false}]}}
```

Base64 encoded chart config:
```
eyJ0eXBlIjoibGluZSIsIm9wdGlvbnMiOnt9LCJkYXRhIjp7ImxhYmVscyI6WyJwZXJmLXJlcG9ydC8xIiwicGVyZi1yZXBvcnQvMiIsInBlcmYtcmVwb3J0LzMiLCJwZXJmLXJlcG9ydC80IiwicGVyZi1yZXBvcnQvNSIsInBlcmYtcmVwb3J0LzYiXSwiZGF0YXNldHMiOlt7InR5cGUiOiJsaW5lIiwibGFiZWwiOiJ0ZXN0LXN1aXRlLTUtdGFyZ2V0cyA+IHRhcmdldC1wYXNzLXZhbHVlLTk5LXRhcmdldC0xMDAtdG9sLTEwIiwiZGF0YSI6Wy0xLC0xLC0yLDQsLTQsOS4wMDAwMDAwMDAwMDAwMTRdLCJmaWxsIjpmYWxzZX0seyJ0eXBlIjoibGluZSIsImxhYmVsIjoidGVzdC1zdWl0ZS01LXRhcmdldHMgPiB0YXJnZXQtcGFzcy12YWx1ZS0xMDAtdGFyZ2V0LTEwMC10b2wtMTAiLCJkYXRhIjpbMCwwLC0xLDUsLTMsMTAuMDAwMDAwMDAwMDAwMDE0XSwiZmlsbCI6ZmFsc2V9LHsidHlwZSI6ImxpbmUiLCJsYWJlbCI6InRlc3Qtc3VpdGUtNS10YXJnZXRzID4gdGFyZ2V0LXBhc3MtdmFsdWUtOTAtdGFyZ2V0LTEwMC10b2wtMTAiLCJkYXRhIjpbLTEwLC0xMCwtMTEsLTUsLTEzLDBdLCJmaWxsIjpmYWxzZX0seyJ0eXBlIjoibGluZSIsImxhYmVsIjoidGVzdC1zdWl0ZS01LXRhcmdldHMgPiB0YXJnZXQtcGFzcy12YWx1ZS04OS10YXJnZXQtMTAwLXRvbC0xMCIsImRhdGEiOlstMTEsLTExLC0xMiwtNiwtMTQsLTFdLCJmaWxsIjpmYWxzZX0seyJ0eXBlIjoibGluZSIsImxhYmVsIjoidGVzdC1zdWl0ZS01LXRhcmdldHMgPiB0YXJnZXQtd2Fybi12YWx1ZS0xMTAtdGFyZ2V0LTEwMC10b2wtMTAiLCJkYXRhIjpbMTAuMDAwMDAwMDAwMDAwMDE0LDEwLjAwMDAwMDAwMDAwMDAxNCw5LjAwMDAwMDAwMDAwMDAxNCwxNC45OTk5OTk5OTk5OTk5ODYsNywyMF0sImZpbGwiOmZhbHNlfSx7InR5cGUiOiJsaW5lIiwibGFiZWwiOiJ0ZXN0LXN1aXRlLTUtdGFyZ2V0cyA+IHRhcmdldC1mYWlsLXZhbHVlLTExMS10YXJnZXQtMTAwLXRvbC0xMCIsImRhdGEiOlsxMS4wMDAwMDAwMDAwMDAwMTQsMTEuMDAwMDAwMDAwMDAwMDE0LDEwLjAwMDAwMDAwMDAwMDAxNCwxNS45OTk5OTk5OTk5OTk5ODYsOCwyMV0sImZpbGwiOmZhbHNlfSx7InR5cGUiOiJsaW5lIiwibGFiZWwiOiJ0ZXN0LXN1aXRlLTUtdGFyZ2V0cyA+IHRhcmdldC1mYWlsLXZhbHVlLTEwMS10YXJnZXQtMTAwLW5vLXRvbCIsImRhdGEiOlsxLDEsMCw2LC0yLDExLjAwMDAwMDAwMDAwMDAxNF0sImZpbGwiOmZhbHNlfV19fQ== 
```