### PR TITLE
Fix License name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,4 +119,4 @@ The hosted QuickChart service uses [monit](https://mmonit.com/monit/) to make su
 
 ## License
 
-QuickChart is open source, licensed under version 3 of the GNU GPL.  If you would like to modify this project for commercial purposes (and not release the source code), please [contact me](https://www.ianww.com/).
+QuickChart is open source, licensed under version 3 of the GNU AGPL.  If you would like to modify this project for commercial purposes (and not release the source code), please [contact me](https://www.ianww.com/).


### PR DESCRIPTION
Just came across this: the README mentions the GPL, while the project is actually licensed under AGPL.