### PR TITLE
Version bump to fix broken violin charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "bunyan": "^1.8.12",
     "chart.js": "^2.9.4",
-    "chartjs-chart-box-and-violin-plot": "^2.2.0",
+    "chartjs-chart-box-and-violin-plot": "^2.4.0",
     "chartjs-chart-radial-gauge": "^1.0.3",
     "chartjs-node-canvas": "https://github.com/typpo/ChartjsNodeCanvas.git#c34802fc3c30e4d1992678134d3ee10d160f65f4",
     "chartjs-plugin-annotation": "^0.5.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -926,10 +926,10 @@ chart.js@^2.9.4:
     chartjs-color "^2.1.0"
     moment "^2.10.2"
 
-chartjs-chart-box-and-violin-plot@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/chartjs-chart-box-and-violin-plot/-/chartjs-chart-box-and-violin-plot-2.3.0.tgz#3ab4510738a089c51746063f5d58f1e62eae4085"
-  integrity sha512-yFluPnxuyorGT0VWmCBeMJACV/BnkdD30QUNTJZgZ7k8vtM6I8pJGCYu41PMyUrjjGpRTn0XD+sGL0Er0yxUeQ==
+chartjs-chart-box-and-violin-plot@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/chartjs-chart-box-and-violin-plot/-/chartjs-chart-box-and-violin-plot-2.4.0.tgz#fa92b00752ceb8712f8892dbbd203dcd39ca0117"
+  integrity sha512-ickfiSacxkOp7wdG23Je25Gbtn8Eh7yMQH8BblriuoqlIi14V3XuX/9XaPGBenKCcYm0dINPZDUvaaXYf8pGqQ==
   dependencies:
     "@sgratzl/science" "^2.0.0"
     chart.js "^2.8.0"


### PR DESCRIPTION
Violin charts stopped working since about a week ago, since 12b9079cdfeb55bb314faab6719d10b0451f880b. E.g. this [violin chart example](https://quickchart.io/chart?c={type:%27violin%27,%20data:{labels:[2012,2013,2014,2015],%20datasets:[{label:%27Data%27,data:[[12,6,3,4],%20[1,8,8,15],[1,1,1,2,3,5,9,8],%20[19,-3,18,8,5,9,9]],%20backgroundColor:%27rgba(56,123,45,0.2)%27,%20borderColor:%27rgba(56,123,45,1.9)%27}]}}) on your website now results in an image containing the text:
> Chart error: "violin" is not a chart type.

Fixed by bumping the chartjs-chart-box-and-violin-plot dependency.