### PR TITLE
Workaround in Dockerfile for successful build on ARM64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN apk add --no-cache --virtual .build-deps yarn git build-base g++ python
 RUN apk add --no-cache --virtual .npm-deps cairo-dev pango-dev libjpeg-turbo-dev
 RUN apk add --no-cache --virtual .fonts libmount ttf-dejavu ttf-droid ttf-freefont ttf-liberation ttf-ubuntu-font-family font-noto font-noto-emoji fontconfig
 RUN apk add wqy-zenhei --no-cache --repository http://nl.alpinelinux.org/alpine/edge/testing --allow-untrusted
+RUN apk add libimagequant-dev --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+RUN apk add vips-dev --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
 RUN apk add --no-cache --virtual .runtime-deps graphviz
 
 COPY package*.json .


### PR DESCRIPTION
Workaround for build errors when building ARM64 Docker image.

Base on change noted [here](https://github.com/lovell/sharp/issues/2498#issuecomment-787924363).

Further testing may be necessary.