### PR TITLE
guard against null/undefined (#114)

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,5 +1,7 @@
 function fixNodeVmObject(obj) {
   // Fix for https://github.com/patriksimek/vm2/issues/198
+  if (!obj) return;
+  
   const objKeys = Object.keys(obj);
   for (let i = 0; i < objKeys.length; i++) {
     const key = objKeys[i];


### PR DESCRIPTION
Fix for [issue 114](https://github.com/typpo/quickchart/issues/114) in which `undefined` entries in a dataset causes a 500.