### PR TITLE
ci: add github action docker push

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,20 @@
+name: CI Checks
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  build_image:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+# Based on official guidance from
+# https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
+
+name: Publish Docker image
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: my-docker-hub-namespace/my-docker-hub-repository
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apk add --no-cache --virtual .runtime-deps graphviz
 
 COPY package*.json .
 COPY yarn.lock .
+RUN yarn global add node-gyp
 RUN yarn install --production
 
 RUN apk update


### PR DESCRIPTION
Closes https://github.com/typpo/quickchart/issues/178

Adds Github Actions to:

- Check that the docker image can be built for each new PR
- Build and push a tagged docker image when a new git tag is pushed to the repo (will tag appropriately for tags of format `x0.0.0`)

This PR also adds installation of `node-gyp` to the docker image, as I was unable to make the build work otherwise.