### PR TITLE
fix: update alpine repo url for font-wqy-zenhei

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --upgrade apk-tools
 RUN apk add --no-cache --virtual .build-deps yarn git build-base g++ python3
 RUN apk add --no-cache --virtual .npm-deps cairo-dev pango-dev libjpeg-turbo-dev librsvg-dev
 RUN apk add --no-cache --virtual .fonts libmount ttf-dejavu ttf-droid ttf-freefont ttf-liberation font-noto font-noto-emoji fontconfig
-RUN apk add --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/edge/testing font-wqy-zenhei
+RUN apk add --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/edge/community font-wqy-zenhei
 RUN apk add --no-cache libimagequant-dev
 RUN apk add --no-cache vips-dev
 RUN apk add --no-cache --virtual .runtime-deps graphviz


### PR DESCRIPTION
Found in our internal build of `quickchart`.

The package `font-wqy-zenhei` has moved from `testing` to `community` on the `edge` branch - this PR updates the installation step accordingly.

Building using the current `Dockerfile` will fail with

```log
35.39 fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/community/x86_64/APKINDEX.tar.gz
35.72 ERROR: unable to select packages:
35.75   font-wqy-zenhei (no such package):
35.75     required by: world[font-wqy-zenhei]
```

ref https://pkgs.alpinelinux.org/packages?name=font-wqy-zenhei&branch=edge&repo=&arch=&maintainer=

![image](https://github.com/typpo/quickchart/assets/12255914/1201a03b-6661-4119-a899-8d3541553f84)
