### PR TITLE
fix chg handling in google image charts

### DIFF
--- a/lib/google_image_charts.js
+++ b/lib/google_image_charts.js
@@ -374,28 +374,6 @@ function setTitle(chtt, chts, chartObj) {
   };
 }
 
-function setGridLines(chg, chartObj) {
-  if (!chg) {
-    return;
-  }
-
-  const splits = chg.split(',');
-  if (splits.length >= 2) {
-    const numGridLinesX = 100 / parseInt(splits[0], 10);
-    const numGridLinesY = 100 / parseInt(splits[1], 10);
-
-    chartObj.options.scales.xAxes[0].ticks = {
-      maxTicksLimit: numGridLinesX,
-    };
-    chartObj.options.scales.yAxes[0].ticks = {
-      maxTicksLimit: numGridLinesY,
-    };
-  }
-
-  // TODO(ian): dash sizes etc
-  // https://developers.google.com/chart/image/docs/gallery/line_charts
-}
-
 function setDataLabels(chl, chartObj) {
   if (!chl) {
     return;
@@ -610,24 +588,31 @@ function setAxesLabels(chxt, chxl, chxs, chartObj) {
     if (chartObj.type === 'horizontalBar') {
       // Horizontal bar charts have x axis ticks.
       chartObj.options.scales.xAxes[0].gridLines = chartObj.options.scales.xAxes[0].gridLines || {};
-      chartObj.options.scales.xAxes[0].gridLines.display = true;
-      chartObj.options.scales.xAxes[0].gridLines.drawOnChartArea = false;
-      chartObj.options.scales.xAxes[0].gridLines.drawTicks = true;
+      chartObj.options.scales.xAxes[0].gridLines.display =
+        chartObj.options.scales.xAxes[0].gridLines.display ?? true;
+      chartObj.options.scales.xAxes[0].gridLines.drawOnChartArea =
+        chartObj.options.scales.xAxes[0].gridLines.drawOnChartArea ?? false;
+      chartObj.options.scales.xAxes[0].gridLines.drawTicks =
+        chartObj.options.scales.xAxes[0].gridLines.drawTicks ?? true;
     }
 
     chartObj.options.scales.xAxes[0].ticks = chartObj.options.scales.xAxes[0].ticks || {};
-    chartObj.options.scales.xAxes[0].ticks.autoSkip = false;
+    chartObj.options.scales.xAxes[0].ticks.autoSkip =
+      chartObj.options.scales.xAxes[0].ticks.autoSkip ?? false;
   }
   if (axes.indexOf('y') > -1) {
     chartObj.options.scales.yAxes[0].display = true;
 
     // Google Image Charts show yAxes ticks.
     chartObj.options.scales.yAxes[0].gridLines = chartObj.options.scales.yAxes[0].gridLines || {};
-    chartObj.options.scales.yAxes[0].gridLines.display = true;
-    chartObj.options.scales.yAxes[0].gridLines.drawOnChartArea = false;
-    chartObj.options.scales.yAxes[0].gridLines.offsetGridLines = false;
-    // TODO(ian): We set drawTicks to false elsewhere... fix this.
-    chartObj.options.scales.yAxes[0].gridLines.drawTicks = true;
+    chartObj.options.scales.yAxes[0].gridLines.display =
+      chartObj.options.scales.yAxes[0].gridLines.display ?? true;
+    chartObj.options.scales.yAxes[0].gridLines.drawOnChartArea =
+      chartObj.options.scales.yAxes[0].gridLines.drawOnChartArea ?? false;
+    chartObj.options.scales.yAxes[0].gridLines.offsetGridLines =
+      chartObj.options.scales.yAxes[0].gridLines.offsetGridLines ?? false;
+    chartObj.options.scales.yAxes[0].gridLines.drawTicks =
+      chartObj.options.scales.yAxes[0].gridLines.drawTicks ?? true;
   }
 
   if (chxs) {
@@ -874,14 +859,29 @@ function setGridLines(chg, chartObj) {
 
   const parts = chg.split(',');
 
-  if (parts[0] > 0) {
+  if (Number(parts[0]) > 0) {
     chartObj.options.scales.xAxes[0].gridLines.display = true;
     chartObj.options.scales.xAxes[0].gridLines.drawOnChartArea = true;
   }
-  if (parts[1] > 0) {
+  if (Number(parts[1]) > 0) {
     chartObj.options.scales.yAxes[0].gridLines.display = true;
     chartObj.options.scales.yAxes[0].gridLines.drawOnChartArea = true;
   }
+
+  if (parts.length >= 2) {
+    const numGridLinesX = 100 / parseInt(parts[0], 10);
+    const numGridLinesY = 100 / parseInt(parts[1], 10);
+
+    chartObj.options.scales.xAxes[0].ticks = {
+      maxTicksLimit: numGridLinesX,
+    };
+    chartObj.options.scales.yAxes[0].ticks = {
+      maxTicksLimit: numGridLinesY,
+    };
+  }
+
+  // TODO(ian): dash sizes etc
+  // https://developers.google.com/chart/image/docs/gallery/line_charts
 
   // TODO(ian): Full implementation https://developers.google.com/chart/image/docs/chart_params#gcharts_grid_lines
 }


### PR DESCRIPTION
Related to #189 

https://quickchart.io/chart?cht=lc&chco=FF0000,00FF00,0000FF&chs=300x200&chd=s:FOETHECat,lkjtf3asv,KATYPSNXJ&chxt=x,y&chxl=0:%7COct%7CNov%7CDec%7C1:%7C%7C20K%7C%7C60K%7C%7C100K&chg=0,1

![google image charts horizontal line grid](https://github.com/typpo/quickchart/assets/310310/74d44d5c-fde8-403f-a92a-e99094f3eb7b)
